### PR TITLE
Use parent DHT host

### DIFF
--- a/lib/socket-pool.js
+++ b/lib/socket-pool.js
@@ -117,7 +117,7 @@ class SocketRef {
       .on('message', this._onmessage.bind(this))
       .on('idle', this._onidle.bind(this))
       .on('busy', this._onbusy.bind(this))
-      .bind()
+      .bind(0, pool._dht.io._host)
 
     this._refs = 1
     this._released = false


### PR DESCRIPTION
@riccardobl proposed this some time ago! This time I used the host from `dht.io`

Reference: https://github.com/riccardobl/hyperswarm-dht/commit/df9aa0d81bc88b08163ce263580e6603305ab44e